### PR TITLE
Use Bootstrap-friendly z-index values

### DIFF
--- a/templates/pace-theme-barber-shop.tmpl.css
+++ b/templates/pace-theme-barber-shop.tmpl.css
@@ -13,7 +13,7 @@
 .pace .pace-progress {
   background-color: `args.color || "#29d"`;
   position: fixed;
-  z-index: 100;
+  z-index: 2000;
   top: 0;
   left: 0;
   height: 12px;

--- a/templates/pace-theme-big-counter.tmpl.css
+++ b/templates/pace-theme-big-counter.tmpl.css
@@ -8,7 +8,7 @@
 
 .pace .pace-progress {
   position: fixed;
-  z-index: 100;
+  z-index: 2000;
   top: 0;
   right: 0;
   height: 5rem;

--- a/templates/pace-theme-bounce.tmpl.css
+++ b/templates/pace-theme-bounce.tmpl.css
@@ -4,7 +4,7 @@
   position: fixed;
   top: -90px;
   right: -20px;
-  z-index: 100;
+  z-index: 2000;
   -webkit-transform: scale(0);
   -moz-transform: scale(0);
   -ms-transform: scale(0);
@@ -32,7 +32,7 @@
   background: `args.color || "#29d"`;
   position: absolute;
   top: 0;
-  z-index: 11;
+  z-index: 1911;
   -webkit-animation: pace-bounce 1s infinite;
   -moz-animation: pace-bounce 1s infinite;
   -o-animation: pace-bounce 1s infinite;
@@ -45,7 +45,7 @@
   display: block;
   left: 50%;
   bottom: 0;
-  z-index: 10;
+  z-index: 1910;
   margin-left: -30px;
   width: 60px;
   height: 75px;

--- a/templates/pace-theme-corner-indicator.tmpl.css
+++ b/templates/pace-theme-corner-indicator.tmpl.css
@@ -9,7 +9,7 @@
 .pace .pace-activity {
   display: block;
   position: fixed;
-  z-index: 100;
+  z-index: 2000;
   top: 0;
   right: 0;
   width: 300px;

--- a/templates/pace-theme-flash.tmpl.css
+++ b/templates/pace-theme-flash.tmpl.css
@@ -13,7 +13,7 @@
 .pace .pace-progress {
   background: `args.color || "#29d"`;
   position: fixed;
-  z-index: 100;
+  z-index: 2000;
   top: 0;
   left: 0;
   height: 2px;
@@ -37,7 +37,7 @@
 .pace .pace-activity {
   display: block;
   position: fixed;
-  z-index: 100;
+  z-index: 2000;
   top: 15px;
   right: 15px;
   width: 14px;

--- a/templates/pace-theme-flat-top.tmpl.css
+++ b/templates/pace-theme-flat-top.tmpl.css
@@ -9,7 +9,7 @@
 .pace .pace-progress {
   display: block;
   position: fixed;
-  z-index: 100;
+  z-index: 2000;
   top: 0;
   left: 0;
   height: 12px;

--- a/templates/pace-theme-mac-osx.tmpl.css
+++ b/templates/pace-theme-mac-osx.tmpl.css
@@ -15,7 +15,7 @@
 
   color: `Color(args.color || "#78c0f0").lighten(0.25).hexString();`;
   position: fixed;
-  z-index: 100;
+  z-index: 2000;
   top: 0;
   left: 0;
   height: 12px;

--- a/templates/pace-theme-minimal.tmpl.css
+++ b/templates/pace-theme-minimal.tmpl.css
@@ -1,7 +1,7 @@
 .pace .pace-progress {
   background: `args.color || "#29d"`;
   position: fixed;
-  z-index: 100;
+  z-index: 2000;
   top: 0;
   left: 0;
   height: 2px;

--- a/themes/pace-theme-barber-shop.css
+++ b/themes/pace-theme-barber-shop.css
@@ -14,7 +14,7 @@
 .pace .pace-progress {
   background-color: #29d;
   position: fixed;
-  z-index: 100;
+  z-index: 2000;
   top: 0;
   left: 0;
   height: 12px;

--- a/themes/pace-theme-big-counter.css
+++ b/themes/pace-theme-big-counter.css
@@ -9,7 +9,7 @@
 
 .pace .pace-progress {
   position: fixed;
-  z-index: 100;
+  z-index: 2000;
   top: 0;
   right: 0;
   height: 5rem;

--- a/themes/pace-theme-bounce.css
+++ b/themes/pace-theme-bounce.css
@@ -5,7 +5,7 @@
   position: fixed;
   top: -90px;
   right: -20px;
-  z-index: 100;
+  z-index: 2000;
   -webkit-transform: scale(0);
   -moz-transform: scale(0);
   -ms-transform: scale(0);
@@ -33,7 +33,7 @@
   background: #29d;
   position: absolute;
   top: 0;
-  z-index: 11;
+  z-index: 1911;
   -webkit-animation: pace-bounce 1s infinite;
   -moz-animation: pace-bounce 1s infinite;
   -o-animation: pace-bounce 1s infinite;
@@ -46,7 +46,7 @@
   display: block;
   left: 50%;
   bottom: 0;
-  z-index: 10;
+  z-index: 1910;
   margin-left: -30px;
   width: 60px;
   height: 75px;

--- a/themes/pace-theme-corner-indicator.css
+++ b/themes/pace-theme-corner-indicator.css
@@ -10,7 +10,7 @@
 .pace .pace-activity {
   display: block;
   position: fixed;
-  z-index: 100;
+  z-index: 2000;
   top: 0;
   right: 0;
   width: 300px;

--- a/themes/pace-theme-flash.css
+++ b/themes/pace-theme-flash.css
@@ -14,7 +14,7 @@
 .pace .pace-progress {
   background: #29d;
   position: fixed;
-  z-index: 100;
+  z-index: 2000;
   top: 0;
   left: 0;
   height: 2px;
@@ -38,7 +38,7 @@
 .pace .pace-activity {
   display: block;
   position: fixed;
-  z-index: 100;
+  z-index: 2000;
   top: 15px;
   right: 15px;
   width: 14px;

--- a/themes/pace-theme-flat-top.css
+++ b/themes/pace-theme-flat-top.css
@@ -10,7 +10,7 @@
 .pace .pace-progress {
   display: block;
   position: fixed;
-  z-index: 100;
+  z-index: 2000;
   top: 0;
   left: 0;
   height: 12px;

--- a/themes/pace-theme-mac-osx.css
+++ b/themes/pace-theme-mac-osx.css
@@ -16,7 +16,7 @@
 
   color: #CBE7F9;
   position: fixed;
-  z-index: 100;
+  z-index: 2000;
   top: 0;
   left: 0;
   height: 12px;

--- a/themes/pace-theme-minimal.css
+++ b/themes/pace-theme-minimal.css
@@ -2,7 +2,7 @@
 .pace .pace-progress {
   background: #29d;
   position: fixed;
-  z-index: 100;
+  z-index: 2000;
   top: 0;
   left: 0;
   height: 2px;


### PR DESCRIPTION
Bootstrap uses z-index values up to 1050 currently, so we'll use
z-index values around 2000 so progress indications appear above
e.g. a navbar element.
