### PR TITLE
fixed example typo. there is no pace-theme-barber-pole.css, it is barber-shop

### DIFF
--- a/docs/intro.md
+++ b/docs/intro.md
@@ -18,7 +18,7 @@ Example
 ```html
 <head>
   <script src="/pace/pace.js"></script>
-  <link href="/pace/themes/pace-theme-barber-pole.css" rel="stylesheet" />
+  <link href="/pace/themes/pace-theme-barber-shop.css" rel="stylesheet" />
 </head>
 ```
 


### PR DESCRIPTION
May have been a typo in the example on the documentation page. I was confused for a minute why it didn't work. Others might have same problem. 
