### PR TITLE
Intro improvements (typo & link to opening issues)

### DIFF
--- a/docs/intro.md
+++ b/docs/intro.md
@@ -110,8 +110,8 @@ Elements
 Elements being rendered to the screen is one way for us to decide that the page has been
 rendered.  If you would like to use that source of information (not required at all),
 specify one or more selectors.  You can comma seperate the selectors to propertly handle
-error states, where the progress bar should disappear, but the element were looking for
-may never apper:
+error states, where the progress bar should disappear, but the element we are looking for
+may never appear:
 
 ```javascript
 paceOptions = {

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -183,7 +183,7 @@ Issues
 ------
 
 We have obviously not tested this on every website.  If you run into an issue, or find a way the automatic
-detection could be better, please create an Issue.  If you can include a test case, that's even better.
+detection could be better, please [create an Issue](https://github.com/HubSpot/pace/issues/new).  If you can include a test case, that's even better.
 
 Contributing
 ------------


### PR DESCRIPTION
Nothing ground breaking here, just some minor changes to `pace`'s introduction - namely fixing a typo and adding a link for opening issues.
