### PR TITLE
#84 ie8 stops at 98 or 99% and will not complete page load

### DIFF
--- a/pace.coffee
+++ b/pace.coffee
@@ -259,7 +259,7 @@ class Bar
     @lastRenderedProgress = @progress
 
   done: ->
-    @progress >= 100
+    @progress >= 98
 
 class Events
   constructor: ->


### PR DESCRIPTION
Solution for #84. Check https://github.com/HubSpot/pace/issues/84 -done function considered to be completed over 98%.
