### PR TITLE
Exclude docs, tests, and other development-only files from Bower package

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -23,7 +23,13 @@
   ],
   "license": "MIT",
   "ignore": [
+    ".*",
+    "Gruntfile.coffee",
+    "bower_components",
+    "docs",
     "node_modules",
-    "bower_components"
+    "package.json",
+    "templates",
+    "tests"
   ]
 }


### PR DESCRIPTION
This matches other popular Bower packages (e.g., Bootstrap and d3).
