### PR TITLE
Bump version in docs and README (master)

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ pace
 
 An automatic web page progress bar.
 
-Include [pace.js](https://raw.github.com/HubSpot/pace/v0.4.14/pace.min.js) and a [theme](http://github.hubspot.com/pace/docs/welcome/) of your choice to your page and you are done!
+Include [pace.js](https://raw.github.com/HubSpot/pace/v0.5.0/pace.min.js) and a [theme](http://github.hubspot.com/pace/docs/welcome/) of your choice to your page and you are done!
 
 Pace will automatically monitor your Ajax requests, event loop lag, document ready state and elements on your page to decide on the progress.
 

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -1,7 +1,7 @@
 pace
 ====
 
-Include [pace.js](https://raw.github.com/HubSpot/pace/v0.4.17/pace.min.js) and the
+Include [pace.js](https://raw.github.com/HubSpot/pace/v0.5.0/pace.min.js) and the
 [theme](http://github.hubspot.com/pace/docs/welcome/) css of your choice on your page
 (as early as is possible), and you're done!
 

--- a/docs/welcome/index.html
+++ b/docs/welcome/index.html
@@ -433,7 +433,7 @@
                 <p style="text-align: left">No need to hook into any of your code, progress is detected automatically.</p>
                 <br/>
                 <h2>Download</h2>
-                <p><a class="button" href="https://raw.github.com/HubSpot/pace/v0.4.17/pace.min.js">Pace.js</a></p>
+                <p><a class="button" href="https://raw.github.com/HubSpot/pace/v0.5.0/pace.min.js">Pace.js</a></p>
                 <br/>
                 <h2>Themes</h2>
                 <label class="color-label" for="color-select">Enter a color:</label>


### PR DESCRIPTION
Basically the same as #104, but for the master branch and including the README.

To be honest, I’m not really sure where all the docs are used, but I figured they should all point to the most recent release.
