### PR TITLE
Fixes a reference error when window isn't the global context.

### DIFF
--- a/pace.js
+++ b/pace.js
@@ -202,8 +202,10 @@
 
   })();
 
+  var Pace = window.Pace || {};
+
   if (window.Pace == null) {
-    window.Pace = {};
+    window.Pace = Pace;
   }
 
   extend(Pace, Evented.prototype);


### PR DESCRIPTION
This is the case in node (which we found running automated tests on views that require Pace). `window` isn't the global context so setting `window.Pace` doesn't make `Pace` referencable.
