### PR TITLE
Adding main key to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "pace",
+  "main": "./pace.js",
   "version": "0.5.6",
   "description": "Automatic page load progress bar",
   "authors": [


### PR DESCRIPTION
This will make it work with `Webpack`.

Also wonder why wont you register a `pacejs` package at npmjs.org
Browsers starts speak CommonJS natively.
