### PR TITLE
Fix addEventListener for older version Firefox

### DIFF
--- a/pace.coffee
+++ b/pace.coffee
@@ -445,10 +445,12 @@ class XHRRequestTracker
           # response, all we can do is increment the progress with backoff such that we
           # never hit 100% until it's done.
           @progress = @progress + (100 - @progress) / 2
+      , false
 
       for event in ['load', 'abort', 'timeout', 'error']
         request.addEventListener event, =>
           @progress = 100
+        , false
 
     else
       _onreadystatechange = request.onreadystatechange
@@ -467,6 +469,7 @@ class SocketRequestTracker
     for event in ['error', 'open']
       request.addEventListener event, =>
         @progress = 100
+      , false
 
 class ElementMonitor
   constructor: (options={}) ->

--- a/pace.js
+++ b/pace.js
@@ -573,13 +573,13 @@
           } else {
             return _this.progress = _this.progress + (100 - _this.progress) / 2;
           }
-        });
+        }, false);
         _ref2 = ['load', 'abort', 'timeout', 'error'];
         for (_j = 0, _len1 = _ref2.length; _j < _len1; _j++) {
           event = _ref2[_j];
           request.addEventListener(event, function() {
             return _this.progress = 100;
-          });
+          }, false);
         }
       } else {
         _onreadystatechange = request.onreadystatechange;
@@ -609,7 +609,7 @@
         event = _ref2[_j];
         request.addEventListener(event, function() {
           return _this.progress = 100;
-        });
+        }, false);
       }
     }
 


### PR DESCRIPTION
I kept getting these errors in Firefox 3.6.25:

uncaught exception: [Exception... "Not enough arguments" nsresult: "0x80570001 (NS_ERROR_XPC_NOT_ENOUGH_ARGS)" location: "JS frame :: http://[removed]/js/pace.js :: anonymous :: line 570" data: no]

The third argument for `addEventListener` and `removeEventListener`
is supposed to be optional, defaulting to `false`, but some browsers
(notably older versions of FireFox) require it.

https://developer.mozilla.org/en-US/docs/Web/API/EventTarget.removeEventListener
